### PR TITLE
fix(jspm): specify jspm registry in package.json. resolve #10

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,38 @@
     "url": "http://github.com/aurelia/logging"
   },
   "jspm": {
+    "registry": "jspm",
     "main": "index",
     "format": "amd",
     "directories": {
       "lib": "dist/amd"
+    },
+    "devDependencies": {
+      "aurelia-tools": "^0.1.6",
+      "babel-dts-generator": "^0.2.5",
+      "conventional-changelog": "0.0.11",
+      "del": "^1.1.0",
+      "gulp": "^3.8.10",
+      "gulp-babel": "^5.1.0",
+      "gulp-bump": "^0.1.11",
+      "gulp-jshint": "^1.9.0",
+      "gulp-rename": "^1.2.2",
+      "gulp-yuidoc": "^0.1.2",
+      "jasmine-core": "^2.1.3",
+      "jshint-stylish": "^1.0.0",
+      "karma": "^0.12.28",
+      "karma-babel-preprocessor": "^5.2.1",
+      "karma-chrome-launcher": "^0.1.7",
+      "karma-coverage": "^0.3.1",
+      "karma-jasmine": "^0.3.5",
+      "karma-jspm": "^1.1.5",
+      "object.assign": "^1.0.3",
+      "require-dir": "^0.1.0",
+      "run-sequence": "^1.0.2",
+      "traceur": "github:jmcriffey/bower-traceur@0.0.88",
+      "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.88",
+      "vinyl-paths": "^1.0.0",
+      "yargs": "^2.1.1"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Adding this line to package.json fixes the issue with not being able to run `jspm install` on this repo, and thus not being able to run the unit tests.