### PR TITLE
fix(logging): fix the interface

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -178,6 +178,8 @@ export function setLevel(level: number): void {
 * A logger logs messages to a set of appenders, depending on the log level that is set.
 */
 export class Logger {
+  id: string;
+
   /**
   * You cannot instantiate the logger directly - you must use the getLogger method instead.
   */


### PR DESCRIPTION
Expose the 'id' attribute of Logger class.

If one wants to create a custom `Appender` in typescript then the `id` attribute of `Logger` must be declared.