### PR TITLE
feat(logging): add per-logger-instance control of log level

### DIFF
--- a/dist/amd/aurelia-logging.d.ts
+++ b/dist/amd/aurelia-logging.d.ts
@@ -127,36 +127,36 @@ declare module 'aurelia-logging' {
     /**
        * Logs a debug message.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    debug(message: string): void;
+    debug(...args: any[]): void;
     
     /**
        * Logs info.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    info(message: string): void;
+    info(...args: any[]): void;
     
     /**
        * Logs a warning.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    warn(message: string): void;
+    warn(...args: any[]): void;
     
     /**
        * Logs an error.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    error(message: string): void;
+    error(...args: any[]): void;
     
     /**
        * Sets the level of logging this logger
        *
        * @param level Matches a value of logLevel specifying the level of logging.
        */
-    setLevel(level: LogLevel): void;
+    setLevel(level: number): void;
   }
 }

--- a/dist/amd/aurelia-logging.d.ts
+++ b/dist/amd/aurelia-logging.d.ts
@@ -98,7 +98,7 @@ declare module 'aurelia-logging' {
   export function addAppender(appender: Appender): void;
   
   /**
-  * Sets the level of logging for the application loggers.
+  * Sets the level of logging for ALL the application loggers.
   *
   * @param level Matches a value of logLevel specifying the level of logging.
   */
@@ -113,6 +113,11 @@ declare module 'aurelia-logging' {
       * The id that the logger was created with.
       */
     id: string;
+    
+    /**
+       * The logging severity level for this logger
+       */
+    currentLevel: number;
     
     /**
       * You cannot instantiate the logger directly - you must use the getLogger method instead.
@@ -146,5 +151,12 @@ declare module 'aurelia-logging' {
        * @param message The message to log.
        */
     error(message: string): void;
+    
+    /**
+       * Sets the level of logging this logger
+       *
+       * @param level Matches a value of logLevel specifying the level of logging.
+       */
+    setLevel(level: LogLevel): void;
   }
 }

--- a/dist/amd/aurelia-logging.js
+++ b/dist/amd/aurelia-logging.js
@@ -122,13 +122,13 @@ define(['exports'], function (exports) {
       this.id = id;
     }
 
-    Logger.prototype.debug = function debug(message) {};
+    Logger.prototype.debug = function debug() {};
 
-    Logger.prototype.info = function info(message) {};
+    Logger.prototype.info = function info() {};
 
-    Logger.prototype.warn = function warn(message) {};
+    Logger.prototype.warn = function warn() {};
 
-    Logger.prototype.error = function error(message) {};
+    Logger.prototype.error = function error() {};
 
     Logger.prototype.setLevel = function setLevel(level) {
       this.currentLevel = level;

--- a/dist/amd/aurelia-logging.js
+++ b/dist/amd/aurelia-logging.js
@@ -23,7 +23,6 @@ define(['exports'], function (exports) {
   };
 
   var loggers = {};
-  var currentLevel = logLevel.none;
   var appenders = [];
   var slice = Array.prototype.slice;
   var loggerConstructionKey = {};
@@ -42,7 +41,7 @@ define(['exports'], function (exports) {
   }
 
   function debug() {
-    if (currentLevel < 4) {
+    if (this.currentLevel < 4) {
       return;
     }
 
@@ -50,7 +49,7 @@ define(['exports'], function (exports) {
   }
 
   function info() {
-    if (currentLevel < 3) {
+    if (this.currentLevel < 3) {
       return;
     }
 
@@ -58,7 +57,7 @@ define(['exports'], function (exports) {
   }
 
   function warn() {
-    if (currentLevel < 2) {
+    if (this.currentLevel < 2) {
       return;
     }
 
@@ -66,7 +65,7 @@ define(['exports'], function (exports) {
   }
 
   function error() {
-    if (currentLevel < 1) {
+    if (this.currentLevel < 1) {
       return;
     }
 
@@ -105,12 +104,16 @@ define(['exports'], function (exports) {
   }
 
   function setLevel(level) {
-    currentLevel = level;
+    for (var key in loggers) {
+      loggers[key].setLevel(level);
+    }
   }
 
   var Logger = exports.Logger = function () {
     function Logger(id, key) {
       _classCallCheck(this, Logger);
+
+      this.currentLevel = logLevel.none;
 
       if (key !== loggerConstructionKey) {
         throw new Error('You cannot instantiate "Logger". Use the "getLogger" API instead.');
@@ -126,6 +129,10 @@ define(['exports'], function (exports) {
     Logger.prototype.warn = function warn(message) {};
 
     Logger.prototype.error = function error(message) {};
+
+    Logger.prototype.setLevel = function setLevel(level) {
+      this.currentLevel = level;
+    };
 
     return Logger;
   }();

--- a/dist/aurelia-logging.d.ts
+++ b/dist/aurelia-logging.d.ts
@@ -127,36 +127,36 @@ declare module 'aurelia-logging' {
     /**
        * Logs a debug message.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    debug(message: string): void;
+    debug(...args: any[]): void;
     
     /**
        * Logs info.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    info(message: string): void;
+    info(...args: any[]): void;
     
     /**
        * Logs a warning.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    warn(message: string): void;
+    warn(...args: any[]): void;
     
     /**
        * Logs an error.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    error(message: string): void;
+    error(...args: any[]): void;
     
     /**
        * Sets the level of logging this logger
        *
        * @param level Matches a value of logLevel specifying the level of logging.
        */
-    setLevel(level: LogLevel): void;
+    setLevel(level: number): void;
   }
 }

--- a/dist/aurelia-logging.d.ts
+++ b/dist/aurelia-logging.d.ts
@@ -98,7 +98,7 @@ declare module 'aurelia-logging' {
   export function addAppender(appender: Appender): void;
   
   /**
-  * Sets the level of logging for the application loggers.
+  * Sets the level of logging for ALL the application loggers.
   *
   * @param level Matches a value of logLevel specifying the level of logging.
   */
@@ -113,6 +113,11 @@ declare module 'aurelia-logging' {
       * The id that the logger was created with.
       */
     id: string;
+    
+    /**
+       * The logging severity level for this logger
+       */
+    currentLevel: number;
     
     /**
       * You cannot instantiate the logger directly - you must use the getLogger method instead.
@@ -146,5 +151,12 @@ declare module 'aurelia-logging' {
        * @param message The message to log.
        */
     error(message: string): void;
+    
+    /**
+       * Sets the level of logging this logger
+       *
+       * @param level Matches a value of logLevel specifying the level of logging.
+       */
+    setLevel(level: LogLevel): void;
   }
 }

--- a/dist/aurelia-logging.js
+++ b/dist/aurelia-logging.js
@@ -36,7 +36,6 @@ export const logLevel: LogLevel = {
 };
 
 let loggers = {};
-let currentLevel = logLevel.none;
 let appenders = [];
 let slice = Array.prototype.slice;
 let loggerConstructionKey = {};
@@ -55,7 +54,7 @@ function log(logger, level, args) {
 }
 
 function debug() {
-  if (currentLevel < 4) {
+  if (this.currentLevel < 4) {
     return;
   }
 
@@ -63,7 +62,7 @@ function debug() {
 }
 
 function info() {
-  if (currentLevel < 3) {
+  if (this.currentLevel < 3) {
     return;
   }
 
@@ -71,7 +70,7 @@ function info() {
 }
 
 function warn() {
-  if (currentLevel < 2) {
+  if (this.currentLevel < 2) {
     return;
   }
 
@@ -79,7 +78,7 @@ function warn() {
 }
 
 function error() {
-  if (currentLevel < 1) {
+  if (this.currentLevel < 1) {
     return;
   }
 
@@ -166,12 +165,14 @@ export function addAppender(appender: Appender): void {
 }
 
 /**
-* Sets the level of logging for the application loggers.
+* Sets the level of logging for ALL the application loggers.
 *
 * @param level Matches a value of logLevel specifying the level of logging.
 */
 export function setLevel(level: number): void {
-  currentLevel = level;
+  for (let key in loggers) {
+    loggers[key].setLevel(level);
+  }
 }
 
 /**
@@ -182,6 +183,11 @@ export class Logger {
   * The id that the logger was created with.
   */
   id: string;
+
+  /**
+   * The logging severity level for this logger
+   */
+  currentLevel : number = logLevel.none;
 
   /**
   * You cannot instantiate the logger directly - you must use the getLogger method instead.
@@ -221,4 +227,13 @@ export class Logger {
    * @param message The message to log.
    */
   error(message: string): void {}
+
+  /**
+   * Sets the level of logging this logger
+   *
+   * @param level Matches a value of logLevel specifying the level of logging.
+   */
+  setLevel(level: LogLevel): void {
+    this.currentLevel = level;
+  }
 }

--- a/dist/aurelia-logging.js
+++ b/dist/aurelia-logging.js
@@ -203,37 +203,37 @@ export class Logger {
   /**
    * Logs a debug message.
    *
-   * @param message The message to log.
+   * @param args the data to log
    */
-  debug(message: string): void {}
+  debug(...args:any[]): void {}
 
   /**
    * Logs info.
    *
-   * @param message The message to log.
+   * @param args the data to log
    */
-  info(message: string): void {}
+  info(...args:any[]): void {}
 
   /**
    * Logs a warning.
    *
-   * @param message The message to log.
+   * @param args the data to log
    */
-  warn(message: string): void {}
+  warn(...args:any[]): void {}
 
   /**
    * Logs an error.
    *
-   * @param message The message to log.
+   * @param args the data to log
    */
-  error(message: string): void {}
+  error(...args:any[]): void {}
 
   /**
    * Sets the level of logging this logger
    *
    * @param level Matches a value of logLevel specifying the level of logging.
    */
-  setLevel(level: LogLevel): void {
+  setLevel(level: number): void {
     this.currentLevel = level;
   }
 }

--- a/dist/commonjs/aurelia-logging.d.ts
+++ b/dist/commonjs/aurelia-logging.d.ts
@@ -127,36 +127,36 @@ declare module 'aurelia-logging' {
     /**
        * Logs a debug message.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    debug(message: string): void;
+    debug(...args: any[]): void;
     
     /**
        * Logs info.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    info(message: string): void;
+    info(...args: any[]): void;
     
     /**
        * Logs a warning.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    warn(message: string): void;
+    warn(...args: any[]): void;
     
     /**
        * Logs an error.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    error(message: string): void;
+    error(...args: any[]): void;
     
     /**
        * Sets the level of logging this logger
        *
        * @param level Matches a value of logLevel specifying the level of logging.
        */
-    setLevel(level: LogLevel): void;
+    setLevel(level: number): void;
   }
 }

--- a/dist/commonjs/aurelia-logging.d.ts
+++ b/dist/commonjs/aurelia-logging.d.ts
@@ -98,7 +98,7 @@ declare module 'aurelia-logging' {
   export function addAppender(appender: Appender): void;
   
   /**
-  * Sets the level of logging for the application loggers.
+  * Sets the level of logging for ALL the application loggers.
   *
   * @param level Matches a value of logLevel specifying the level of logging.
   */
@@ -113,6 +113,11 @@ declare module 'aurelia-logging' {
       * The id that the logger was created with.
       */
     id: string;
+    
+    /**
+       * The logging severity level for this logger
+       */
+    currentLevel: number;
     
     /**
       * You cannot instantiate the logger directly - you must use the getLogger method instead.
@@ -146,5 +151,12 @@ declare module 'aurelia-logging' {
        * @param message The message to log.
        */
     error(message: string): void;
+    
+    /**
+       * Sets the level of logging this logger
+       *
+       * @param level Matches a value of logLevel specifying the level of logging.
+       */
+    setLevel(level: LogLevel): void;
   }
 }

--- a/dist/commonjs/aurelia-logging.js
+++ b/dist/commonjs/aurelia-logging.js
@@ -18,7 +18,6 @@ var logLevel = exports.logLevel = {
 };
 
 var loggers = {};
-var currentLevel = logLevel.none;
 var appenders = [];
 var slice = Array.prototype.slice;
 var loggerConstructionKey = {};
@@ -37,7 +36,7 @@ function log(logger, level, args) {
 }
 
 function debug() {
-  if (currentLevel < 4) {
+  if (this.currentLevel < 4) {
     return;
   }
 
@@ -45,7 +44,7 @@ function debug() {
 }
 
 function info() {
-  if (currentLevel < 3) {
+  if (this.currentLevel < 3) {
     return;
   }
 
@@ -53,7 +52,7 @@ function info() {
 }
 
 function warn() {
-  if (currentLevel < 2) {
+  if (this.currentLevel < 2) {
     return;
   }
 
@@ -61,7 +60,7 @@ function warn() {
 }
 
 function error() {
-  if (currentLevel < 1) {
+  if (this.currentLevel < 1) {
     return;
   }
 
@@ -100,12 +99,16 @@ function addAppender(appender) {
 }
 
 function setLevel(level) {
-  currentLevel = level;
+  for (var key in loggers) {
+    loggers[key].setLevel(level);
+  }
 }
 
 var Logger = exports.Logger = function () {
   function Logger(id, key) {
     _classCallCheck(this, Logger);
+
+    this.currentLevel = logLevel.none;
 
     if (key !== loggerConstructionKey) {
       throw new Error('You cannot instantiate "Logger". Use the "getLogger" API instead.');
@@ -121,6 +124,10 @@ var Logger = exports.Logger = function () {
   Logger.prototype.warn = function warn(message) {};
 
   Logger.prototype.error = function error(message) {};
+
+  Logger.prototype.setLevel = function setLevel(level) {
+    this.currentLevel = level;
+  };
 
   return Logger;
 }();

--- a/dist/commonjs/aurelia-logging.js
+++ b/dist/commonjs/aurelia-logging.js
@@ -117,13 +117,13 @@ var Logger = exports.Logger = function () {
     this.id = id;
   }
 
-  Logger.prototype.debug = function debug(message) {};
+  Logger.prototype.debug = function debug() {};
 
-  Logger.prototype.info = function info(message) {};
+  Logger.prototype.info = function info() {};
 
-  Logger.prototype.warn = function warn(message) {};
+  Logger.prototype.warn = function warn() {};
 
-  Logger.prototype.error = function error(message) {};
+  Logger.prototype.error = function error() {};
 
   Logger.prototype.setLevel = function setLevel(level) {
     this.currentLevel = level;

--- a/dist/es2015/aurelia-logging.d.ts
+++ b/dist/es2015/aurelia-logging.d.ts
@@ -127,36 +127,36 @@ declare module 'aurelia-logging' {
     /**
        * Logs a debug message.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    debug(message: string): void;
+    debug(...args: any[]): void;
     
     /**
        * Logs info.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    info(message: string): void;
+    info(...args: any[]): void;
     
     /**
        * Logs a warning.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    warn(message: string): void;
+    warn(...args: any[]): void;
     
     /**
        * Logs an error.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    error(message: string): void;
+    error(...args: any[]): void;
     
     /**
        * Sets the level of logging this logger
        *
        * @param level Matches a value of logLevel specifying the level of logging.
        */
-    setLevel(level: LogLevel): void;
+    setLevel(level: number): void;
   }
 }

--- a/dist/es2015/aurelia-logging.d.ts
+++ b/dist/es2015/aurelia-logging.d.ts
@@ -98,7 +98,7 @@ declare module 'aurelia-logging' {
   export function addAppender(appender: Appender): void;
   
   /**
-  * Sets the level of logging for the application loggers.
+  * Sets the level of logging for ALL the application loggers.
   *
   * @param level Matches a value of logLevel specifying the level of logging.
   */
@@ -113,6 +113,11 @@ declare module 'aurelia-logging' {
       * The id that the logger was created with.
       */
     id: string;
+    
+    /**
+       * The logging severity level for this logger
+       */
+    currentLevel: number;
     
     /**
       * You cannot instantiate the logger directly - you must use the getLogger method instead.
@@ -146,5 +151,12 @@ declare module 'aurelia-logging' {
        * @param message The message to log.
        */
     error(message: string): void;
+    
+    /**
+       * Sets the level of logging this logger
+       *
+       * @param level Matches a value of logLevel specifying the level of logging.
+       */
+    setLevel(level: LogLevel): void;
   }
 }

--- a/dist/es2015/aurelia-logging.js
+++ b/dist/es2015/aurelia-logging.js
@@ -8,7 +8,6 @@ export const logLevel = {
 };
 
 let loggers = {};
-let currentLevel = logLevel.none;
 let appenders = [];
 let slice = Array.prototype.slice;
 let loggerConstructionKey = {};
@@ -27,7 +26,7 @@ function log(logger, level, args) {
 }
 
 function debug() {
-  if (currentLevel < 4) {
+  if (this.currentLevel < 4) {
     return;
   }
 
@@ -35,7 +34,7 @@ function debug() {
 }
 
 function info() {
-  if (currentLevel < 3) {
+  if (this.currentLevel < 3) {
     return;
   }
 
@@ -43,7 +42,7 @@ function info() {
 }
 
 function warn() {
-  if (currentLevel < 2) {
+  if (this.currentLevel < 2) {
     return;
   }
 
@@ -51,7 +50,7 @@ function warn() {
 }
 
 function error() {
-  if (currentLevel < 1) {
+  if (this.currentLevel < 1) {
     return;
   }
 
@@ -90,11 +89,15 @@ export function addAppender(appender) {
 }
 
 export function setLevel(level) {
-  currentLevel = level;
+  for (let key in loggers) {
+    loggers[key].setLevel(level);
+  }
 }
 
 export let Logger = class Logger {
   constructor(id, key) {
+    this.currentLevel = logLevel.none;
+
     if (key !== loggerConstructionKey) {
       throw new Error('You cannot instantiate "Logger". Use the "getLogger" API instead.');
     }
@@ -109,4 +112,8 @@ export let Logger = class Logger {
   warn(message) {}
 
   error(message) {}
+
+  setLevel(level) {
+    this.currentLevel = level;
+  }
 };

--- a/dist/es2015/aurelia-logging.js
+++ b/dist/es2015/aurelia-logging.js
@@ -105,13 +105,13 @@ export let Logger = class Logger {
     this.id = id;
   }
 
-  debug(message) {}
+  debug(...args) {}
 
-  info(message) {}
+  info(...args) {}
 
-  warn(message) {}
+  warn(...args) {}
 
-  error(message) {}
+  error(...args) {}
 
   setLevel(level) {
     this.currentLevel = level;

--- a/dist/system/aurelia-logging.d.ts
+++ b/dist/system/aurelia-logging.d.ts
@@ -127,36 +127,36 @@ declare module 'aurelia-logging' {
     /**
        * Logs a debug message.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    debug(message: string): void;
+    debug(...args: any[]): void;
     
     /**
        * Logs info.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    info(message: string): void;
+    info(...args: any[]): void;
     
     /**
        * Logs a warning.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    warn(message: string): void;
+    warn(...args: any[]): void;
     
     /**
        * Logs an error.
        *
-       * @param message The message to log.
+       * @param args the data to log
        */
-    error(message: string): void;
+    error(...args: any[]): void;
     
     /**
        * Sets the level of logging this logger
        *
        * @param level Matches a value of logLevel specifying the level of logging.
        */
-    setLevel(level: LogLevel): void;
+    setLevel(level: number): void;
   }
 }

--- a/dist/system/aurelia-logging.d.ts
+++ b/dist/system/aurelia-logging.d.ts
@@ -98,7 +98,7 @@ declare module 'aurelia-logging' {
   export function addAppender(appender: Appender): void;
   
   /**
-  * Sets the level of logging for the application loggers.
+  * Sets the level of logging for ALL the application loggers.
   *
   * @param level Matches a value of logLevel specifying the level of logging.
   */
@@ -113,6 +113,11 @@ declare module 'aurelia-logging' {
       * The id that the logger was created with.
       */
     id: string;
+    
+    /**
+       * The logging severity level for this logger
+       */
+    currentLevel: number;
     
     /**
       * You cannot instantiate the logger directly - you must use the getLogger method instead.
@@ -146,5 +151,12 @@ declare module 'aurelia-logging' {
        * @param message The message to log.
        */
     error(message: string): void;
+    
+    /**
+       * Sets the level of logging this logger
+       *
+       * @param level Matches a value of logLevel specifying the level of logging.
+       */
+    setLevel(level: LogLevel): void;
   }
 }

--- a/dist/system/aurelia-logging.js
+++ b/dist/system/aurelia-logging.js
@@ -1,7 +1,7 @@
 'use strict';
 
 System.register([], function (_export, _context) {
-  var logLevel, loggers, currentLevel, appenders, slice, loggerConstructionKey, Logger;
+  var logLevel, loggers, appenders, slice, loggerConstructionKey, Logger;
 
   function _classCallCheck(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
@@ -23,7 +23,7 @@ System.register([], function (_export, _context) {
   }
 
   function debug() {
-    if (currentLevel < 4) {
+    if (this.currentLevel < 4) {
       return;
     }
 
@@ -31,7 +31,7 @@ System.register([], function (_export, _context) {
   }
 
   function info() {
-    if (currentLevel < 3) {
+    if (this.currentLevel < 3) {
       return;
     }
 
@@ -39,7 +39,7 @@ System.register([], function (_export, _context) {
   }
 
   function warn() {
-    if (currentLevel < 2) {
+    if (this.currentLevel < 2) {
       return;
     }
 
@@ -47,7 +47,7 @@ System.register([], function (_export, _context) {
   }
 
   function error() {
-    if (currentLevel < 1) {
+    if (this.currentLevel < 1) {
       return;
     }
 
@@ -85,7 +85,6 @@ System.register([], function (_export, _context) {
       _export('logLevel', logLevel);
 
       loggers = {};
-      currentLevel = logLevel.none;
       appenders = [];
       slice = Array.prototype.slice;
       loggerConstructionKey = {};
@@ -108,7 +107,9 @@ System.register([], function (_export, _context) {
       _export('addAppender', addAppender);
 
       function setLevel(level) {
-        currentLevel = level;
+        for (var key in loggers) {
+          loggers[key].setLevel(level);
+        }
       }
 
       _export('setLevel', setLevel);
@@ -116,6 +117,8 @@ System.register([], function (_export, _context) {
       _export('Logger', Logger = function () {
         function Logger(id, key) {
           _classCallCheck(this, Logger);
+
+          this.currentLevel = logLevel.none;
 
           if (key !== loggerConstructionKey) {
             throw new Error('You cannot instantiate "Logger". Use the "getLogger" API instead.');
@@ -131,6 +134,10 @@ System.register([], function (_export, _context) {
         Logger.prototype.warn = function warn(message) {};
 
         Logger.prototype.error = function error(message) {};
+
+        Logger.prototype.setLevel = function setLevel(level) {
+          this.currentLevel = level;
+        };
 
         return Logger;
       }());

--- a/dist/system/aurelia-logging.js
+++ b/dist/system/aurelia-logging.js
@@ -127,13 +127,13 @@ System.register([], function (_export, _context) {
           this.id = id;
         }
 
-        Logger.prototype.debug = function debug(message) {};
+        Logger.prototype.debug = function debug() {};
 
-        Logger.prototype.info = function info(message) {};
+        Logger.prototype.info = function info() {};
 
-        Logger.prototype.warn = function warn(message) {};
+        Logger.prototype.warn = function warn() {};
 
-        Logger.prototype.error = function error(message) {};
+        Logger.prototype.error = function error() {};
 
         Logger.prototype.setLevel = function setLevel(level) {
           this.currentLevel = level;

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,6 @@ export const logLevel: LogLevel = {
 };
 
 let loggers = {};
-let currentLevel = logLevel.none;
 let appenders = [];
 let slice = Array.prototype.slice;
 let loggerConstructionKey = {};
@@ -55,7 +54,7 @@ function log(logger, level, args) {
 }
 
 function debug() {
-  if (currentLevel < 4) {
+  if (this.currentLevel < 4) {
     return;
   }
 
@@ -63,7 +62,7 @@ function debug() {
 }
 
 function info() {
-  if (currentLevel < 3) {
+  if (this.currentLevel < 3) {
     return;
   }
 
@@ -71,7 +70,7 @@ function info() {
 }
 
 function warn() {
-  if (currentLevel < 2) {
+  if (this.currentLevel < 2) {
     return;
   }
 
@@ -79,7 +78,7 @@ function warn() {
 }
 
 function error() {
-  if (currentLevel < 1) {
+  if (this.currentLevel < 1) {
     return;
   }
 
@@ -166,12 +165,14 @@ export function addAppender(appender: Appender): void {
 }
 
 /**
-* Sets the level of logging for the application loggers.
+* Sets the level of logging for ALL the application loggers.
 *
 * @param level Matches a value of logLevel specifying the level of logging.
 */
 export function setLevel(level: number): void {
-  currentLevel = level;
+  for (let key in loggers) {
+    loggers[key].setLevel(level);
+  }
 }
 
 /**
@@ -182,6 +183,11 @@ export class Logger {
   * The id that the logger was created with.
   */
   id: string;
+
+  /**
+   * The logging severity level for this logger
+   */
+  currentLevel : number = logLevel.none;
 
   /**
   * You cannot instantiate the logger directly - you must use the getLogger method instead.
@@ -221,4 +227,13 @@ export class Logger {
    * @param message The message to log.
    */
   error(message: string): void {}
+
+  /**
+   * Sets the level of logging this logger
+   *
+   * @param level Matches a value of logLevel specifying the level of logging.
+   */
+  setLevel(level: LogLevel): void {
+    this.currentLevel = level;
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -203,37 +203,37 @@ export class Logger {
   /**
    * Logs a debug message.
    *
-   * @param message The message to log.
+   * @param args the data to log
    */
-  debug(message: string): void {}
+  debug(...args:any[]): void {}
 
   /**
    * Logs info.
    *
-   * @param message The message to log.
+   * @param args the data to log
    */
-  info(message: string): void {}
+  info(...args:any[]): void {}
 
   /**
    * Logs a warning.
    *
-   * @param message The message to log.
+   * @param args the data to log
    */
-  warn(message: string): void {}
+  warn(...args:any[]): void {}
 
   /**
    * Logs an error.
    *
-   * @param message The message to log.
+   * @param args the data to log
    */
-  error(message: string): void {}
+  error(...args:any[]): void {}
 
   /**
    * Sets the level of logging this logger
    *
    * @param level Matches a value of logLevel specifying the level of logging.
    */
-  setLevel(level: LogLevel): void {
+  setLevel(level: number): void {
     this.currentLevel = level;
   }
 }


### PR DESCRIPTION
Previously setting logging level applied unilaterally across all loggers (e.g. LogManager.setLevel(...) )
This change moves the notion of  'current log level' down to Logger instances, adding a `setLevel()` method to Logger.
 `LogManager.setLevel()` now  iterates through all loggers and setting log level (hence should have the same effect for consumers as prior to this change).

#18 