### PR TITLE
feat(logging): add per-logger-instance control of log level

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,6 @@ export const logLevel: LogLevel = {
 };
 
 let loggers = {};
-let currentLevel = logLevel.none;
 let appenders = [];
 let slice = Array.prototype.slice;
 let loggerConstructionKey = {};
@@ -55,7 +54,7 @@ function log(logger, level, args) {
 }
 
 function debug() {
-  if (currentLevel < 4) {
+  if (this.currentLevel < 4) {
     return;
   }
 
@@ -63,7 +62,7 @@ function debug() {
 }
 
 function info() {
-  if (currentLevel < 3) {
+  if (this.currentLevel < 3) {
     return;
   }
 
@@ -71,7 +70,7 @@ function info() {
 }
 
 function warn() {
-  if (currentLevel < 2) {
+  if (this.currentLevel < 2) {
     return;
   }
 
@@ -79,7 +78,7 @@ function warn() {
 }
 
 function error() {
-  if (currentLevel < 1) {
+  if (this.currentLevel < 1) {
     return;
   }
 
@@ -166,12 +165,14 @@ export function addAppender(appender: Appender): void {
 }
 
 /**
-* Sets the level of logging for the application loggers.
+* Sets the level of logging for ALL the application loggers.
 *
 * @param level Matches a value of logLevel specifying the level of logging.
 */
 export function setLevel(level: number): void {
-  currentLevel = level;
+  for (let key in loggers) {
+    loggers[key].setLevel(level);
+  }
 }
 
 /**
@@ -182,6 +183,11 @@ export class Logger {
   * The id that the logger was created with.
   */
   id: string;
+
+  /**
+   * The logging severity level for this logger
+   */
+  currentLevel : number = logLevel.none;
 
   /**
   * You cannot instantiate the logger directly - you must use the getLogger method instead.
@@ -225,4 +231,13 @@ export class Logger {
    * @param rest The data to log.
    */
   error(message: string, ...rest: any[]): void {}
+
+  /**
+   * Sets the level of logging this logger
+   *
+   * @param level Matches a value of logLevel specifying the level of logging.
+   */
+  setLevel(level: LogLevel): void {
+    this.currentLevel = level;
+  }
 }


### PR DESCRIPTION
Previously setting logging level applied unilaterally across all loggers (e.g. LogManager.setLevel(...) )
This change moves the notion of  'current log level' down to Logger instances, adding a `setLevel()` method to Logger.
 `LogManager.setLevel()` now  iterates through all loggers and setting log level (hence should have the same effect for consumers as prior to this change).

 #18
(cherry picked from commit 89b04cd)