### PR TITLE
feat(logging): Allow global logLevel to be returned

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -179,6 +179,15 @@ export function setLevel(level: number): void {
 }
 
 /**
+* Gets the level of logging of ALL the application loggers.
+*
+* @return The logLevel value used in all loggers.
+*/
+export function getLevel(): number {
+  return globalDefaultLevel;
+}
+
+/**
 * A logger logs messages to a set of appenders, depending on the log level that is set.
 */
 export class Logger {

--- a/test/logging.spec.js
+++ b/test/logging.spec.js
@@ -135,6 +135,13 @@ describe('The log manager ', () => {
         expect(attemptingToNewUpALogger).toThrow();
     });
 
+  it('should be able to return the global logLevel', () => {
+      LogManager.setLevel(LogManager.logLevel.debug);
+      var globalLogLevel = LogManager.getLevel();
+
+      expect(globalLogLevel).toEqual( LogManager.logLevel.debug);
+  });
+
   describe('setting logLevel per individual logger instance', () =>
   {
     it('should not log if specific logger logLevel is none', () => {


### PR DESCRIPTION
With [this commit](https://github.com/aurelia/logging/commit/ec9af2af17a06574cf827743d8a1c54e27538d53), it became possible to set the global logLevel through the `setLevel` function. You could however, not retrieve this level unless you created a logger. This PR adds a function `getLevel` that simply returns the global logLevel.