### PR TITLE
refactor(index): optimize for minifying

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,11 +62,11 @@ function logFactory(level) {
 }
 
 function connectLoggers() {
-  let proto = Logger.prototype;
-  proto.debug = logFactory('debug');
-  proto.info = logFactory('info');
-  proto.warn = logFactory('warn');
-  proto.error = logFactory('error');
+  const levels = ['debug', 'info', 'warn', 'error'];
+  for (let i = 0, { length } = levels; i < length; i++) {
+    const level = levels[i];
+    Logger.prototype[level] = logFactory(level);
+  }
 }
 
 /**


### PR DESCRIPTION
Tested with the Babili minifier: [before](https://babeljs.io/repl/#?babili=true&evaluate=false&lineWrap=false&presets=&targets=&browsers=&builtIns=false&code=function%20connectLoggers()%20%7B%0A%20%20let%20proto%20%3D%20Logger.prototype%3B%0A%20%20proto.debug%20%3D%20logFactory(%27debug%27)%3B%0A%20%20proto.info%20%3D%20logFactory(%27info%27)%3B%0A%20%20proto.warn%20%3D%20logFactory(%27warn%27)%3B%0A%20%20proto.error%20%3D%20logFactory(%27error%27)%3B%0A%7D) vs [after](https://babeljs.io/repl/#?babili=true&evaluate=false&lineWrap=false&presets=&targets=&browsers=&builtIns=false&code=function%20connectLoggers()%20%7B%0A%20%20const%20levels%20%3D%20%5B%27debug%27%2C%20%27info%27%2C%20%27warn%27%2C%20%27error%27%5D%3B%0A%20%20for%20(let%20i%20%3D%200%2C%20%7B%20length%20%7D%20%3D%20levels%3B%20i%20%3C%20length%3B%20i%2B%2B)%20%7B%0A%20%20%20%20const%20level%20%3D%20levels%5Bi%5D%3B%0A%20%20%20%20Logger.prototype%5Blevel%5D%20%3D%20logFactory(level)%3B%0A%20%20%7D%0A%7D).