### PR TITLE
Relax types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -215,34 +215,30 @@ export class Logger {
   /**
    * Logs a debug message.
    *
-   * @param message The message to log.
-   * @param rest The data to log.
+   * @param args The data to log.
    */
-  debug(message: string, ...rest: any[]): void {}
+  debug(...args: any[]): void {}
 
   /**
    * Logs info.
    *
-   * @param message The message to log.
-   * @param rest The data to log.
+   * @param args The data to log.
    */
-  info(message: string, ...rest: any[]): void {}
+  info(...args: any[]): void {}
 
   /**
    * Logs a warning.
    *
-   * @param message The message to log.
-   * @param rest The data to log.
+   * @param args The data to log.
    */
-  warn(message: string, ...rest: any[]): void {}
+  warn(...args: any[]): void {}
 
   /**
    * Logs an error.
    *
-   * @param message The message to log.
-   * @param rest The data to log.
+   * @param args The data to log.
    */
-  error(message: string, ...rest: any[]): void {}
+  error(...args: any[]): void {}
 
   /**
    * Sets the level of logging for this logger instance


### PR DESCRIPTION
Fix #45 #43 

Just use any as `console.log()` accepts `...any[]` to begin with.

Appender still fine as it takes `logger, ...rest: any[]` also.

But there might cause breaking change as some appenders out there didn't expect first arg to be non-string.