### PR TITLE
feat(log-manager): add custom log levels

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,12 @@ interface LogLevel {
   /**
   * Log all messages.
   */
-  debug: number
+  debug: number,
+
+  /**
+  * Additional log levels defined at runtime.
+  */
+  [level: string]: number
 }
 
 /**
@@ -29,15 +34,20 @@ interface LogLevel {
 */
 export const logLevel: LogLevel = {
   none: 0,
-  error: 1,
-  warn: 2,
-  info: 3,
-  debug: 4
+  error: 10,
+  warn: 20,
+  info: 30,
+  debug: 40
 };
 
 let loggers = {};
 let appenders = [];
 let globalDefaultLevel = logLevel.none;
+
+const standardLevels = ["none", "error", "warn", "info", "debug"];
+function isStandardLevel(level: string) {
+  return standardLevels.filter(l => l === level).length > 0;
+}
 
 function appendArgs() {
   return [this, ...arguments];
@@ -61,12 +71,50 @@ function logFactory(level) {
   };
 }
 
+function logFactoryCustom(level) {
+  //This function is the same as logFactory() except that it checks that the method
+  //is defined on the appender.
+  const threshold = logLevel[level];
+  return function() {
+    // In this function, this === logger
+    if (this.level < threshold) {
+      return;
+    }
+    // We don't want to disable optimizations (such as inlining) in this function
+    // so we do the arguments manipulation in another function.
+    // Note that Function#apply is very special for V8.
+    const args = appendArgs.apply(this, arguments);
+    let i = appenders.length;
+    while (i--) {
+      const appender = appenders[i];
+      if (appender[level] !== undefined) {
+        appender[level](...args);
+      }
+    }
+  };
+}
+
 function connectLoggers() {
   let proto = Logger.prototype;
-  proto.debug = logFactory('debug');
-  proto.info = logFactory('info');
-  proto.warn = logFactory('warn');
-  proto.error = logFactory('error');
+  for (let level in logLevel) {
+    if (isStandardLevel(level)) {
+      if (level !== "none") {
+        proto[level] = logFactory(level);
+      }
+    }
+    else {
+      proto[level] = logFactoryCustom(level);
+    }
+  }
+}
+
+function disconnectLoggers() {
+  let proto = Logger.prototype;
+  for (let level in logLevel) {
+    if (level !== "none") {
+      proto[level] = function() { };
+    }
+  }
 }
 
 /**
@@ -83,6 +131,7 @@ export function getLogger(id: string): Logger {
 * Implemented by classes which wish to append log data to a target data store.
 */
 interface Appender {
+
   /**
   * Appends a debug log.
   *
@@ -128,11 +177,64 @@ export function addAppender(appender: Appender): void {
 }
 
 /**
-* Removes an appender
+* Removes an appender.
 * @param appender An appender that has been added previously.
 */
 export function removeAppender(appender: Appender): void {
   appenders = appenders.filter(a => a !== appender);
+}
+
+/**
+ * Gets an array of all appenders.
+ */
+export function getAppenders() {
+  return [...appenders];
+}
+
+/**
+ * Removes all appenders.
+ */
+export function clearAppenders(): void {
+  appenders = [];
+  disconnectLoggers();
+}
+
+/**
+ * Adds a custom log level that will be added as an additional method to Logger.
+ * Logger will call the corresponding method on any appenders that support it.
+ *
+ * @param name The name for the new log level.
+ * @param value The numeric severity value for the level (higher is more severe).
+ */
+export function addCustomLevel(name: string, value: number): void {
+  if (logLevel[name] !== undefined) {
+    throw Error(`Log level "${name}" already exists.`);
+  }
+  if (isNaN(value)) {
+    throw Error("Value must be a number.");
+  }
+  logLevel[name] = value;
+  if (appenders.length > 0) {
+    //Reinitialize the Logger prototype with the new method.
+    connectLoggers();
+  }
+  else {
+    //Add the custom level as a noop by default.
+    Logger.prototype[name] = function() { };
+  }
+}
+
+/**
+ * Removes a custom log level.
+ * @param name The name of a custom log level that has been added previously.
+ */
+export function removeCustomLevel(name: string): void {
+  if (logLevel[name] === undefined)
+    return;
+  if (isStandardLevel(name))
+    throw Error(`Built-in log level "${name}" cannot be removed.`);
+  delete logLevel[name];
+  delete Logger.prototype[name];
 }
 
 /**

--- a/test/custom-levels.spec.js
+++ b/test/custom-levels.spec.js
@@ -1,0 +1,140 @@
+import * as LogManager from '../src/index';
+
+describe('The log manager', () => {
+  var logName = 'test', logger, testAppender, customLevelAppender;
+  var customLevel = { name: 'trace', value: 35 }; // Value between info and debug.
+
+  class TestAppender {
+    debug(args) { }
+    info(args){}
+    warn(args){}
+    error(args){}
+  }
+
+  class CustomLevelAppender {
+    debug(args) { }
+    info(args){}
+    warn(args){}
+    error(args){}
+    trace(args){}
+  }
+
+  beforeEach(() => {
+    LogManager.clearAppenders();
+    testAppender = new TestAppender();
+    customLevelAppender = new CustomLevelAppender();
+  });
+
+  function addLevel() { LogManager.addCustomLevel(customLevel.name, customLevel.value); }
+  function removeLevel() { LogManager.removeCustomLevel(customLevel.name) }
+
+  describe('calling addCustomLevel', () => {
+    describe('should add level to logLevels', () => {
+      beforeEach(addLevel);
+      afterEach(removeLevel);
+
+      it('with provided name', () => {
+        expect(LogManager.logLevel[customLevel.name]).toBeDefined();
+      });
+
+      it('with the provided severity value', () => {
+        expect(LogManager.logLevel[customLevel.name]).toBe(customLevel.value);
+      });
+    });
+
+    it('should throw when level exists.', () => {
+      expect(() => { LogManager.addCustomLevel("info", customLevel.value) }).toThrow();
+    });
+
+    it('should throw when severity value is not a number.', () => {
+      expect(() => { LogManager.addCustomLevel(customLevel.name, "Invalid") }).toThrow();
+    });
+
+    function addsLevelAsMethod() {
+      it('adds the level as a method of Logger', () => {
+        const logger = LogManager.getLogger(logName);
+        expect(logger.trace).toBeUndefined();
+        addLevel();
+        expect(typeof logger.trace).toBe("function");
+        removeLevel();
+      });
+    }
+
+    describe('before appenders have been added', () => {
+      addsLevelAsMethod();
+    });
+
+    describe('after appenders have been added', () => {
+      beforeEach(() => {
+        LogManager.addAppender(testAppender);
+        LogManager.addAppender(customLevelAppender);
+      });
+
+      addsLevelAsMethod();
+    });
+  });
+
+  describe('calling removeCustomLevel', () => {
+    it('removes level from logLevels', () => {
+      addLevel();
+      expect(LogManager.logLevel[customLevel.name]).toBeDefined();
+      removeLevel();
+      expect(LogManager.logLevel[customLevel.name]).toBeUndefined();
+    });
+
+    it('does nothing if level does not exist.', () => {
+      expect(() => { LogManager.removeCustomLevel("nonexistent"); }).not.toThrow();
+    });
+
+    let level;
+    for (level in LogManager.logLevels) {
+      it(`should throw when called with built-in level "${level}"`, () => {
+        expect(() => { LogManager.removeCustomLevel(level); }).toThrow();
+      });
+    }
+
+    it('removes the level as a method of Logger', () => {
+      const logger = LogManager.getLogger(logName);
+      addLevel();
+      expect(logger.trace).toBeDefined();
+      removeLevel();
+      expect(logger.trace).toBeUndefined();
+    });
+
+  });
+
+  describe('', () => {
+    beforeEach(() => {
+      addLevel();
+      LogManager.clearAppenders();
+      customLevelAppender = new CustomLevelAppender();
+      spyOn(customLevelAppender, 'trace');
+    });
+    afterEach(removeLevel);
+
+    it('calls custom method on supported appenders.', () => {
+      LogManager.addAppender(customLevelAppender);
+      const logger = LogManager.getLogger(logName);
+      logger.setLevel(LogManager.logLevel.debug);
+      logger.trace('foo');
+      expect(customLevelAppender.trace.calls.count()).toBe(1);
+    });
+
+    it('does not call custom method on appender when level is higher than custom severity value.', () => {
+      LogManager.addAppender(customLevelAppender);
+      const logger = LogManager.getLogger(logName);
+      logger.setLevel(LogManager.logLevel.info);
+      logger.trace('foo');
+      expect(customLevelAppender.trace.calls.count()).toBe(0);
+    });
+
+    it('does not attempt to call custom method on unsupported appenders.', () => {
+      testAppender = new TestAppender();
+      LogManager.addAppender(testAppender);
+      const logger = LogManager.getLogger(logName);
+      logger.setLevel(LogManager.logLevel.debug);
+      expect(() => { logger.trace('foo'); }).not.toThrow();
+    });
+  });
+
+});

--- a/test/logging.spec.js
+++ b/test/logging.spec.js
@@ -29,17 +29,44 @@ describe('The log manager ', () => {
       spyOn(testAppender, 'warn');
       spyOn(testAppender, 'error');
 
+      LogManager.clearAppenders();
       LogManager.addAppender(testAppender);
 
       logger = LogManager.getLogger(logName);
       LogManager.setLevel(LogManager.logLevel.none);
     });
 
+  describe('when calling getAppenders ', () => {
+    it('should return an array of added appenders', () => {
+      const testAppender2 = new TestAppender();
+      LogManager.addAppender(testAppender2);
+      const appenders = LogManager.getAppenders();
+      expect(appenders instanceof Array).toBeTruthy();
+      expect(appenders).toEqual([testAppender, testAppender2]);
+    });
+
+    it('should not expose the internal appenders array', () => {
+      LogManager.getAppenders().push(new TestAppender());
+      expect(LogManager.getAppenders()).toEqual([testAppender]);
+    });
+  });
+
+  it('should remove all appenders when calling clearAppenders', () => {
+    LogManager.addAppender(new TestAppender());
+    expect(LogManager.getAppenders().length).toBe(2);
+    LogManager.clearAppenders();
+    expect(LogManager.getAppenders().length).toBe(0);
+  });
+
   it('should remove the test appender', () => {
     LogManager.setLevel(LogManager.logLevel.debug);
     LogManager.removeAppender(testAppender);
     logger.debug('foo');
-      expect(testAppender.debug.calls.count()).toBe(0)
+    expect(testAppender.debug.calls.count()).toBe(0);
+  });
+
+  it('should not add logLevel "none" as a method of Logger.', () => {
+    expect(logger.none).toBeUndefined();
   });
   
   it('should call only call debug when logLevel is debug', () => {
@@ -58,7 +85,7 @@ describe('The log manager ', () => {
       LogManager.setLevel(LogManager.logLevel.none);
       logger.debug('foo');
 
-      expect(testAppender.debug.calls.count()).toBe(1)
+      expect(testAppender.debug.calls.count()).toBe(1);
   });
 
   it('should call only call info when logLevel is debug or info', () => {
@@ -77,7 +104,7 @@ describe('The log manager ', () => {
       LogManager.setLevel(LogManager.logLevel.none);
       logger.info('foo');
 
-      expect(testAppender.info.calls.count()).toBe(2)
+      expect(testAppender.info.calls.count()).toBe(2);
   });
 
   it('should call only call warn when logLevel is debug, info, or warn', () => {
@@ -96,7 +123,7 @@ describe('The log manager ', () => {
       LogManager.setLevel(LogManager.logLevel.none);
       logger.warn('foo');
 
-      expect(testAppender.warn.calls.count()).toBe(3)
+      expect(testAppender.warn.calls.count()).toBe(3);
   });
 
   it('should call only call error when logLevel is debug, info, warn, or error', () => {
@@ -115,7 +142,7 @@ describe('The log manager ', () => {
       LogManager.setLevel(LogManager.logLevel.none);
       logger.error('foo');
 
-      expect(testAppender.error.calls.count()).toBe(4)
+      expect(testAppender.error.calls.count()).toBe(4);
   });
 
   it('should pass arguments to the appender', () => {


### PR DESCRIPTION
Adds methods addCustomLevel(name, value) and removeCustomLevel(name)
to LogManager. For testing purposes, but also of general use, adds
clearAppenders() and getAppenders().  Adding a custom level adds a
method of the corresponding name to the Logger interface.  This change
is needed to enable the logger to replace console for existing functions
like trace, time/timeEnd, etc, as well as to support custom behavior
for additional logging use cases. In my case, I need an exception()
method to format passed error stacks to submit to an error reporting
service.

There should be no breaking changes. Closes issue #33.