### PR TITLE
feat(logging): Allow isDebugEnabled to be returned

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -331,4 +331,11 @@ export class Logger {
   setLevel(level: number): void {
     this.level = level;
   }
+
+  /**
+   * Returns if the logger is in debug mode or not.
+   */
+  isDebugEnabled(): boolean {
+    return this.level === logLevel.debug;
+  }
 }

--- a/test/logging.spec.js
+++ b/test/logging.spec.js
@@ -176,6 +176,17 @@ describe('The log manager ', () => {
       expect(globalLogLevel).toEqual( LogManager.logLevel.debug);
   });
 
+  it('should be able to tell if the log level is debug', () => {
+    LogManager.setLevel(LogManager.logLevel.debug);
+    var isDebugEnabledAtDebugLevel = logger.isDebugEnabled();
+
+    LogManager.setLevel(LogManager.logLevel.warn);
+    var isDebugEnabledAtWarnLevel = logger.isDebugEnabled();
+
+    expect(isDebugEnabledAtDebugLevel).toEqual(true);
+    expect(isDebugEnabledAtWarnLevel).toEqual(false);
+  });
+
   describe('setting logLevel per individual logger instance', () =>
   {
     it('should not log if specific logger logLevel is none', () => {


### PR DESCRIPTION
This will allow for debug checks to be ran prior to expensive logging
statements being crafted.

This contains no breaking changes and should resolve issue
[#41](https://github.com/aurelia/logging/issues/41)